### PR TITLE
US974183: Add jq to dotnet build image

### DIFF
--- a/buildenv-dotnet-image/src/main/docker/Dockerfile
+++ b/buildenv-dotnet-image/src/main/docker/Dockerfile
@@ -18,7 +18,7 @@ ARG JDK17_IMAGE
 FROM $JDK17_IMAGE
 CMD ["bash"]
 
-RUN zypper -n install libicu wget
+RUN zypper -n install jq libicu wget
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
 RUN wget https://packages.microsoft.com/config/opensuse/15/prod.repo
 RUN mv prod.repo /etc/zypp/repos.d/microsoft-prod.repo

--- a/buildenv-dotnet-image/src/main/docker/Dockerfile
+++ b/buildenv-dotnet-image/src/main/docker/Dockerfile
@@ -18,7 +18,7 @@ ARG JDK17_IMAGE
 FROM $JDK17_IMAGE
 CMD ["bash"]
 
-RUN zypper -n install jq libicu wget
+RUN zypper -n install libicu wget
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
 RUN wget https://packages.microsoft.com/config/opensuse/15/prod.repo
 RUN mv prod.repo /etc/zypp/repos.d/microsoft-prod.repo

--- a/buildenv-dotnet-mono-image/src/main/docker/Dockerfile
+++ b/buildenv-dotnet-mono-image/src/main/docker/Dockerfile
@@ -25,4 +25,4 @@ RUN zypper -n addrepo https://download.opensuse.org/repositories/home:lemmy04/15
     rm dev_zypper_repo_key.pub && \
     zypper -n refresh && \
     zypper -n update && \
-    zypper -n install msbuild
+    zypper -n jq install msbuild

--- a/release-notes-4.1.0.md
+++ b/release-notes-4.1.0.md
@@ -4,5 +4,6 @@
 ${version-number}
 
 #### New Features
+- US974183: Added jq utility.
 
 #### Known Issues


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=974183


Required for https://gitlab.otxlab.net/cybersecurity-enterprise/cddri/agent/adaptersdk-dotnet-samples/-/blob/US974183/scripts/copy_packages.sh?ref_type=heads
